### PR TITLE
Do not restart apache

### DIFF
--- a/1.23/Dockerfile
+++ b/1.23/Dockerfile
@@ -37,7 +37,7 @@ RUN set -x; \
     && docker-php-ext-configure ldap \
     && docker-php-ext-install ldap
 
-RUN a2enmod rewrite && php5enmod ldap && service apache2 restart
+RUN a2enmod rewrite && php5enmod ldap
 
 # https://www.mediawiki.org/keys/keys.txt
 RUN gpg --keyserver pool.sks-keyservers.net --recv-keys \


### PR DESCRIPTION
Restarting apache is essentially pointless, because it is not running and does not run until after the `entrypoint.sh` has completed and called `exec "$@"` which calls `apache2-foreground` since that is what is configured in the `CMD` statement in this `Dockerfile`.